### PR TITLE
Update to support ASDF 0.16+ only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 circleci-asdf-installer
 ---
 
-A tool that aims to simplify installing and using asdf in circleci configurations. This tool is built for ubuntu, but it
+A tool that aims to simplify installing and using asdf 0.16+ in circleci configurations. This tool is built for ubuntu, but it
 will probably work with other distributions. You will need to install any dependencies as your first step, before
 running the other steps shown below.
+
+**Note**: This tool now supports ASDF 0.16+ only. The binary version of ASDF is downloaded and installed automatically.
 
 ### Supported features
 

--- a/bin/clone-asdf
+++ b/bin/clone-asdf
@@ -6,14 +6,45 @@ function print_message {
   printf -- "--> %s...\n" "$1"
 }
 
-function install_asdf {
-  print_message "Installing ASDF"
-  git clone https://github.com/asdf-vm/asdf.git "$HOME/.asdf"
+function detect_architecture {
+  local arch=$(uname -m)
+  local os=$(uname -s | tr '[:upper:]' '[:lower:]')
+  
+  case "$arch" in
+    x86_64) arch="amd64" ;;
+    aarch64|arm64) arch="arm64" ;;
+    *) echo "Unsupported architecture: $arch" >&2; exit 1 ;;
+  esac
+  
+  echo "${os}-${arch}"
 }
 
-# circleci runs with a dynamic bash environment file, so we need to append our asdf-sourcing to that file
+function install_asdf {
+  local arch_string=$(detect_architecture)
+  local latest_url="https://api.github.com/repos/asdf-vm/asdf/releases/latest"
+  local download_url=$(curl -s "$latest_url" | grep "browser_download_url.*${arch_string}\.tar\.gz\"" | head -1 | cut -d '"' -f 4)
+  
+  if [ -z "$download_url" ]; then
+    echo "Could not find ASDF binary for architecture: $arch_string" >&2
+    exit 1
+  fi
+  
+  print_message "Installing ASDF 0.16+"
+  mkdir -p "$HOME/.asdf/bin"
+  
+  # Download and extract the tar.gz file
+  local temp_file=$(mktemp)
+  curl -sL "$download_url" -o "$temp_file"
+  
+  # Extract to bin directory
+  tar -xzf "$temp_file" -C "$HOME/.asdf/bin"
+  rm "$temp_file"
+}
+
 function make_asdf_available_later {
-  echo ". \"$HOME/.asdf/asdf.sh\"" >> "$BASH_ENV"
+  export ASDF_DATA_DIR="$HOME/.asdf"
+  echo "export ASDF_DATA_DIR=\"$HOME/.asdf\"" >> "$BASH_ENV"
+  echo "export PATH=\"\$ASDF_DATA_DIR/bin:\$ASDF_DATA_DIR/shims:\$PATH\"" >> "$BASH_ENV"
 }
 
 install_asdf

--- a/bin/install-asdf-plugins-and-versions
+++ b/bin/install-asdf-plugins-and-versions
@@ -47,12 +47,12 @@ function tool_versions {
 function install_plugins {
   # Iterate through the list of tool names and add each one as an ASDF plugin
   local TOOL_NAMES=($(tool_versions | awk '{print $1}'))
-  local INSTALLED_TOOLS=$(asdf plugin-list)
+  local INSTALLED_TOOLS=$(asdf plugin list)
 
   for tool_name in "${TOOL_NAMES[@]}"; do
     if ! printf '%s\n' "${INSTALLED_TOOLS[@]}" | grep -q "^$tool_name$"; then
       print_message "Adding ASDF plugin for $tool_name"
-      asdf plugin-add "$tool_name"
+      asdf plugin add "$tool_name"
     else
       print_message "Plugin for $tool_name is already installed"
     fi


### PR DESCRIPTION
### 💡 What it is

This PR updates the circleci-asdf-installer to support ASDF 0.16+ exclusively, replacing the previous Git-based installation with the new binary download method.

### ❓ Why

ASDF 0.16+ represents a complete rewrite in Go that introduces breaking changes in both installation methods and command syntax. The old Git-based installation and hyphenated commands are no longer supported.

### 🔧 How

• Updated `bin/clone-asdf` to download ASDF binary from GitHub releases instead of Git cloning
• Added architecture detection for amd64/arm64 compatibility  
• Modified environment setup to use `ASDF_DATA_DIR` and proper PATH configuration
• Updated `bin/install-asdf-plugins-and-versions` to use new command syntax (`plugin list` and `plugin add`)
• Added documentation noting ASDF 0.16+ only support

### 🧪 Testing

The changes maintain the same interface and workflow but use the new ASDF 0.16+ binary and command syntax. Testing should verify that plugins are installed correctly and tools are available after installation.